### PR TITLE
set_volume_size_limit

### DIFF
--- a/cinder/db/sqlalchemy/migrate_repo/versions/042_add_per_volume_quota.py
+++ b/cinder/db/sqlalchemy/migrate_repo/versions/042_add_per_volume_quota.py
@@ -1,0 +1,65 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import timeutils
+from sqlalchemy import MetaData, Table
+
+from cinder.i18n import _LE
+
+# Get default value via config. The default will either
+# come from the default value set in the quota configuration option
+# or via cinder.conf if the user has configured
+# default value for per volume size limit there.
+
+CONF = cfg.CONF
+CONF.import_opt('per_volume_size_limit', 'cinder.quota')
+LOG = logging.getLogger(__name__)
+
+
+def upgrade(migrate_engine):
+    """Add default "per_volume_gigabytes" row into DB."""
+    meta = MetaData()
+    meta.bind = migrate_engine
+    quota_classes = Table('quota_classes', meta, autoload=True)
+    row = quota_classes.count().\
+        where(quota_classes.c.resource == 'per_volume_gigabytes').\
+        execute().scalar()
+
+    # Do not add entry if there is already 'default' entry exists
+    # in the database.
+    # We don't want to write over something the user added.
+    if row:
+        return
+
+    try:
+        # Set default per_volume_gigabytes for per volume size
+        qci = quota_classes.insert()
+        qci.execute({'created_at': timeutils.utcnow(),
+                     'class_name': 'default',
+                     'resource': 'per_volume_gigabytes',
+                     'hard_limit': CONF.per_volume_size_limit,
+                     'deleted': False, })
+    except Exception:
+        LOG.error(_LE("Default per_volume_gigabytes row not inserted "
+                      "into the quota_classes."))
+        raise
+
+
+def downgrade(migrate_engine):
+    """Don't delete the 'default' entries at downgrade time.
+    We don't know if the user had default entries when we started.
+    If they did, we wouldn't want to remove them.  So, the safest
+    thing to do is just leave the 'default' entries at downgrade time.
+    """
+    pass

--- a/cinder/exception.py
+++ b/cinder/exception.py
@@ -454,6 +454,11 @@ class VolumeSizeExceedsAvailableQuota(QuotaError):
                 "%(consumed)sG has been consumed.")
 
 
+class VolumeSizeExceedsLimit(QuotaError):
+    message = _("Requested volume size %(size)d is larger than "
+                "maximum allowed limit %(limit)d.")
+
+
 class VolumeBackupSizeExceedsAvailableQuota(QuotaError):
     message = _("Requested backup exceeds allowed Backup gigabytes "
                 "quota. Requested %(requested)sG, quota is %(quota)sG and "

--- a/cinder/quota.py
+++ b/cinder/quota.py
@@ -69,7 +69,10 @@ quota_opts = [
     cfg.BoolOpt('use_default_quota_class',
                 default=True,
                 help='Enables or disables use of default quota class '
-                     'with default quota.'), ]
+                     'with default quota.'),
+    cfg.IntOpt('per_volume_size_limit',
+               default=-1,
+               help='Max size allowed per volume, in gigabytes'), ]
 
 CONF = cfg.CONF
 CONF.register_opts(quota_opts)
@@ -524,7 +527,8 @@ class ReservableResource(BaseResource):
         """
 
         super(ReservableResource, self).__init__(name, flag=flag)
-        self.sync = sync
+        if sync:
+            self.sync = sync
 
 
 class AbsoluteResource(BaseResource):
@@ -871,6 +875,7 @@ class VolumeTypeQuotaEngine(QuotaEngine):
         result = {}
         # Global quotas.
         argses = [('volumes', '_sync_volumes', 'quota_volumes'),
+                  ('per_volume_gigabytes', None, 'per_volume_size_limit'),
                   ('snapshots', '_sync_snapshots', 'quota_snapshots'),
                   ('gigabytes', '_sync_gigabytes', 'quota_gigabytes'),
                   ('backups', '_sync_backups', 'quota_backups'),

--- a/cinder/tests/api/contrib/test_quotas.py
+++ b/cinder/tests/api/contrib/test_quotas.py
@@ -30,12 +30,13 @@ from cinder import test
 
 def make_body(root=True, gigabytes=1000, snapshots=10,
               volumes=10, backups=10, backup_gigabytes=1000,
-              tenant_id='foo'):
+              tenant_id='foo', per_volume_gigabytes=-1):
     resources = {'gigabytes': gigabytes,
                  'snapshots': snapshots,
                  'volumes': volumes,
                  'backups': backups,
-                 'backup_gigabytes': backup_gigabytes}
+                 'backup_gigabytes': backup_gigabytes,
+                 'per_volume_gigabytes': per_volume_gigabytes, }
     # need to consider preexisting volume types as well
     volume_types = db.volume_type_get_all(context.get_admin_context())
     for volume_type in volume_types:

--- a/cinder/tests/api/contrib/test_quotas_classes.py
+++ b/cinder/tests/api/contrib/test_quotas_classes.py
@@ -33,13 +33,14 @@ QUOTAS = quota.QUOTAS
 
 def make_body(root=True, gigabytes=1000, snapshots=10,
               volumes=10, backups=10,
-              backup_gigabytes=1000,
+              backup_gigabytes=1000, per_volume_gigabytes=-1,
               volume_types_faked=None,
               tenant_id='foo'):
     resources = {'gigabytes': gigabytes,
                  'snapshots': snapshots,
                  'volumes': volumes,
                  'backups': backups,
+                 'per_volume_gigabytes': per_volume_gigabytes,
                  'backup_gigabytes': backup_gigabytes}
     if not volume_types_faked:
         volume_types_faked = {'fake_type': None}

--- a/cinder/volume/flows/api/create_volume.py
+++ b/cinder/volume/flows/api/create_volume.py
@@ -579,6 +579,15 @@ class QuotaReserveTask(flow_utils.CinderTask):
 
     def execute(self, context, size, volume_type_id, optional_args):
         try:
+            values = {'per_volume_gigabytes': size}
+            QUOTAS.limit_check(context, project_id=context.project_id,
+                               **values)
+        except exception.OverQuota as e:
+            quotas = e.kwargs['quotas']
+            raise exception.VolumeSizeExceedsLimit(
+                size=size, limit=quotas['per_volume_gigabytes'])
+
+        try:
             reserve_opts = {'volumes': 1, 'gigabytes': size}
             QUOTAS.add_volume_type_opts(context, reserve_opts, volume_type_id)
             reservations = QUOTAS.reserve(context, **reserve_opts)


### PR DESCRIPTION
Set max volume size limit for the tenant

There is a need to limit maximum size of a volume to levels
that the storage infrastructure can handle.
Setting a maximum limit on size of a volume also prevents
a tenant from creating large volumes that have not been tested
and certified to satisfy SLA objectives.