### PR TITLE
SBS-IAM-INTEGRATION

### DIFF
--- a/cinder/policy.py
+++ b/cinder/policy.py
@@ -25,11 +25,20 @@ CONF = cfg.CONF
 
 _ENFORCER = None
 
+class DisabledEnforcer():
+    def enforce(self, *args, **kwargs):
+        """Disabled policy engine in Cinder
+
+        Policy enforcement is no more done at cinder for SBS.
+        Its now done by IAM in keystone.
+        So, this method is just a  pass-through.
+        """
+        return True
 
 def init():
     global _ENFORCER
     if not _ENFORCER:
-        _ENFORCER = policy.Enforcer()
+        _ENFORCER = DisabledEnforcer()
 
 
 def enforce_action(context, action):

--- a/etc/cinder/api-paste.ini
+++ b/etc/cinder/api-paste.ini
@@ -15,10 +15,13 @@ keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext a
 keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv1
 
 [composite:openstack_volume_api_v2]
-use = call:cinder.api.middleware.auth:pipeline_factory
+use = call:jio_auth_middleware:pipeline_factory
 noauth = request_id faultwrap sizelimit osprofiler noauth apiv2
-keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv2
+keystone = request_id faultwrap sizelimit osprofiler jioauth authtoken keystonecontext apiv2
 keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv2
+
+[filter:jioauth]
+paste.filter_factory = jio_auth_middleware:filter_factory
 
 [filter:request_id]
 paste.filter_factory = oslo_middleware.request_id:RequestId.factory

--- a/etc/cinder/mapping.json
+++ b/etc/cinder/mapping.json
@@ -1,0 +1,149 @@
+{
+"resource_format" : "jrn:jcs:tenant_id:resourceType",
+
+
+"/v2/{tenant_id}/backups"                           : {
+    "POST" : [{
+        "action": "jrn:jcs:sbs:createBackup",
+        "resourceType": "backup"}],
+    "GET" : [{
+        "action": "jrn:jcs:sbs:listBackups",
+        "isResourceIdRequired" : "true",
+        "resourceType": "backup"}]
+},
+"/v2/{tenant_id}/backups/detail"                    : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:listBackupsDetail",
+        "resourceType": "backup"}]
+},
+"/v2/{tenant_id}/backups/{backup_id}"               : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showBackup",
+        "isResourceIdRequired" : "true",
+        "resourceType": "backup"}],
+    "DELETE" : [{
+        "action": "jrn:jcs:sbs:deleteBackup",
+        "isResourceIdRequired" : "true",
+        "resourceType": "backup"}]
+}, 
+"/v2/{tenant_id}/backups/{backup_id}/action"        : {
+    "POST" : {
+    "os-force_delete" : [{
+        "action": "jrn:jcs:sbs:forceDeleteBackup",
+        "isResourceIdRequired" : "true",
+        "resourceType": "backup"}]}
+},
+
+
+"/v2/{tenant_id}/volumes"                       :  {
+    "POST" : [{
+        "action": "jrn:jcs:sbs:createVolume",
+        "resourceType": "volume"}],
+    "GET" : [{
+        "action": "jrn:jcs:sbs:listVolumes",
+        "resourceType": "volume"}]
+},
+"/v2/{tenant_id}/volumes/detail"                :  {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:listVolumesDetail",
+        "resourceType": "volume"}]
+},
+"/v2/{tenant_id}/volumes/{volume_id}"           :  {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showVolume",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "PUT" : [{
+        "action": "jrn:jcs:sbs:updateVolume",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "DELETE" : [{
+        "action": "jrn:jcs:sbs:deleteVolume",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}]
+}, 
+"/v2/{tenant_id}/volumes/{volume_id}/metadata"  :  {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showVolumeMetadata",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "PUT" : [{
+        "action": "jrn:jcs:sbs:updateVolumeMetadata",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}]
+}, 
+"/v2/{tenant_id}/volumes/{volume_id}/action"    :  {
+    "POST" : {
+    "os-reset_status" : [{
+        "action" : "jrn:jcs:sbs:resetVolumeStatus",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "os-set_image_metadata" : [{
+        "action" : "jrn:jcs:sbs:setImageMetadata",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "os-unset_image_metadata" : [{
+        "action" : "jrn:jcs:sbs:unsetImageMetadata",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "os-attach" : [{
+        "action" : "jrn:jcs:sbs:attachVolume",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}],
+    "os-force_detach" : [{
+        "action" : "jrn:jcs:sbs:forceDetachVolume",
+        "isResourceIdRequired" : "true",
+        "resourceType": "volume"}]}
+},
+"/v2/{tenant_id}/os-vol-image-meta" : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showImageMetadata",
+        "resourceType": "volume"}]
+},
+	
+
+"/v2/{tenant_id}/os-quota-sets/defaults"               : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showDefaultQuotas",
+        "resourceType": "quota"}]
+},
+"/v2/{tenant_id}/os-quota-sets/{tenant_id}"            : { 
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}],
+    "PUT" : [{
+        "action": "jrn:jcs:sbs:updateQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}],
+    "DELETE" : [{
+        "action": "jrn:jcs:sbs:deleteQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}]
+}, 
+"/v2/{tenant_id}/os-quota-sets/{tenant_id}/{user_id}"  : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showUserQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}],
+    "PUT" : [{
+        "action": "jrn:jcs:sbs:updateUserQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}],
+    "DELETE" : [{
+        "action": "jrn:jcs:sbs:deleteUserQuotas",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}]
+}, 
+"/v2/{tenant_id}/os-quota-sets/{tenant_id}/detail/{user_id}"  : {
+    "GET" : [{
+        "action": "jrn:jcs:sbs:showUserQuotasDetail",
+        "isResourceIdRequired" : "true",
+        "resourceType": "quota"}]
+}, 
+"/v2/{tenant_id}/limits" : {
+    "GET" : [{
+       "action": "jrn:jcs:sbs:showAbsoluteLimits",
+       "resourceType": "quota"}]
+} 
+}

--- a/etc/cinder/mapping.json
+++ b/etc/cinder/mapping.json
@@ -38,7 +38,8 @@
 "/v2/{tenant_id}/volumes"                       :  {
     "POST" : [{
         "action": "jrn:jcs:sbs:createVolume",
-        "resourceType": "volume"}],
+        "isResourceIdRequired" : "true",
+        "resourceType": "tenant_id"}],
     "GET" : [{
         "action": "jrn:jcs:sbs:listVolumes",
         "resourceType": "volume"}]
@@ -89,11 +90,23 @@
     "os-attach" : [{
         "action" : "jrn:jcs:sbs:attachVolume",
         "isResourceIdRequired" : "true",
+        "resourceType": "instance",
+        "resourceParamSource": "jsonBody",
+        "jsonPath": "os-attach.instance_uuid"},
+        {
+        "action" : "jrn:jcs:sbs:attachVolume",
+        "isResourceIdRequired" : "true",
         "resourceType": "volume"}],
     "os-force_detach" : [{
         "action" : "jrn:jcs:sbs:forceDetachVolume",
         "isResourceIdRequired" : "true",
-        "resourceType": "volume"}]}
+        "resourceType": "volume"},
+        {
+        "action" : "jrn:jcs:sbs:forceDetachVolume",
+        "isResourceIdRequired" : "true",
+        "resourceParamSource": "jsonBody",
+        "jsonPath": "os-force_detach.attachment_id",
+        "resourceType": "attachment"}]}
 },
 "/v2/{tenant_id}/os-vol-image-meta" : {
     "GET" : [{
@@ -105,45 +118,45 @@
 "/v2/{tenant_id}/os-quota-sets/defaults"               : {
     "GET" : [{
         "action": "jrn:jcs:sbs:showDefaultQuotas",
-        "resourceType": "quota"}]
+        "resourceType": "tenant_id"}]
 },
 "/v2/{tenant_id}/os-quota-sets/{tenant_id}"            : { 
     "GET" : [{
         "action": "jrn:jcs:sbs:showQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}],
+        "resourceType": "tenant_id"}],
     "PUT" : [{
         "action": "jrn:jcs:sbs:updateQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}],
+        "resourceType": "tenant_id"}],
     "DELETE" : [{
         "action": "jrn:jcs:sbs:deleteQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}]
+        "resourceType": "tenant_id"}]
 }, 
 "/v2/{tenant_id}/os-quota-sets/{tenant_id}/{user_id}"  : {
     "GET" : [{
         "action": "jrn:jcs:sbs:showUserQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}],
+        "resourceType": "tenant_id"}],
     "PUT" : [{
         "action": "jrn:jcs:sbs:updateUserQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}],
+        "resourceType": "tenant_id"}],
     "DELETE" : [{
         "action": "jrn:jcs:sbs:deleteUserQuotas",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}]
+        "resourceType": "tenant_id"}]
 }, 
 "/v2/{tenant_id}/os-quota-sets/{tenant_id}/detail/{user_id}"  : {
     "GET" : [{
         "action": "jrn:jcs:sbs:showUserQuotasDetail",
         "isResourceIdRequired" : "true",
-        "resourceType": "quota"}]
+        "resourceType": "tenant_id"}]
 }, 
 "/v2/{tenant_id}/limits" : {
     "GET" : [{
        "action": "jrn:jcs:sbs:showAbsoluteLimits",
-       "resourceType": "quota"}]
-} 
+       "resourceType": "tenant_id"}]
+}
 }


### PR DESCRIPTION
Each service will now communicate to IAM, the resource ID and action ID as two additional parameters in token validation API (new Authorize API). IAM will verify based on its policies and respond to the service with all the details that token API did, with an additional “Yes” or “No” response- whether a user is allowed to perform the action on that specific resource.

To cater to these new IAM changes, a new middleware is added; it communicates to IAM, the action and the associated resource corresponding to each API.
https://github.com/vivekdhayaal/jiocloud_auth_middleware

Note that this middleware is added for cinder-v2 API only. Since we don't support v1 we should disable v1 in prod through config options.

* cinder/policy.py
  + Disabled policy check at cinder

* etc/cinder/api-paste.ini
  + Added the new middleware for cinder-v2 API

* etc/cinder/mapping.json
  + Mapping between API urls, actions and resources

https://blueprints.launchpad.net/jio/+spec/sbs-iam-integration

Implements bp sbs-iam-integration