### PR TITLE
Support versioning of backup drivers

### DIFF
--- a/cinder/db/sqlalchemy/migrate_repo/versions/044_add_version_to_backups.py
+++ b/cinder/db/sqlalchemy/migrate_repo/versions/044_add_version_to_backups.py
@@ -15,7 +15,7 @@
 # Copyright (c) 2016 Shishir Gowda <shishir.gowda@ril.com>
 
 from oslo_log import log as logging
-from sqlalchemy import Column, MetaData, String, Table
+from sqlalchemy import Column, MetaData, Table, Float
 
 from cinder.i18n import _LE
 
@@ -27,13 +27,13 @@ def upgrade(migrate_engine):
     meta.bind = migrate_engine
 
     backups = Table('backups', meta, autoload=True)
-    time_stamp = Column('time_stamp', String(length=255))
+    version = Column('version', Float(precision='3,1'))
 
     try:
-        backups.create_column(time_stamp)
-        backups.update().values(time_stamp=None).execute()
+        backups.create_column(version)
+        backups.update().values(version=None).execute()
     except Exception:
-        LOG.error(_LE("Adding time_stamp column to backups table failed."))
+        LOG.error(_LE("Adding version column to backups table failed."))
         raise
 
 
@@ -42,10 +42,10 @@ def downgrade(migrate_engine):
     meta.bind = migrate_engine
 
     backups = Table('backups', meta, autoload=True)
-    time_stamp = backups.columns.time_stamp
+    version = backups.columns.version
 
     try:
-        backups.drop_column(time_stamp)
+        backups.drop_column(version)
     except Exception:
-        LOG.error(_LE("Dropping time_stamp column from backups table failed."))
+        LOG.error(_LE("Dropping version column from backups table failed."))
         raise

--- a/cinder/db/sqlalchemy/models.py
+++ b/cinder/db/sqlalchemy/models.py
@@ -22,7 +22,7 @@ SQLAlchemy models for cinder data.
 from oslo_config import cfg
 from oslo_db.sqlalchemy import models
 from oslo_utils import timeutils
-from sqlalchemy import Column, Integer, String, Text, schema
+from sqlalchemy import Column, Integer, String, Text, schema, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship, backref, validates
@@ -526,6 +526,7 @@ class Backup(BASE, CinderBase):
     size = Column(Integer)
     object_count = Column(Integer)
     time_stamp = Column(String(255))
+    version = Column(Float(precision='3,1'))
 
     @validates('fail_reason')
     def validate_fail_reason(self, key, fail_reason):


### PR DESCRIPTION
Continuation of JBS-23

We want to make sure the snapshots/backups stored are identified with a version, so that in the
future if we deviate in the way we take/restore and backup snapshots, we should have the ability
to atleast restore/delete older version backups

As for creation, it is always good to support only newer version.
Also, if backups exist for a volume, make sure different versions are not supported on the same

Signed-off-by: shishir gowda <shishir.gowda@ril.com>