### PR TITLE
cinder-HA

### DIFF
--- a/cinder/tests/test_volume_utils.py
+++ b/cinder/tests/test_volume_utils.py
@@ -632,6 +632,41 @@ class VolumeUtilsTestCase(test.TestCase):
         self.assertEqual(
             volume_utils.extract_host(host, 'pool', True), 'Pool')
 
+    @mock.patch('cinder.volume.utils.CONF')
+    def test_only_hostname_required(self, mock_conf):
+        mock_conf.rpc_backend = 'zmq'
+        self.assertTrue(volume_utils.only_hostname_required())
+        mock_conf.rpc_backend = 'rabbit'
+        self.assertFalse(volume_utils.only_hostname_required())
+
+    @mock.patch('cinder.volume.utils.CONF')
+    def test_get_volume_rpc_host(self, mock_conf):
+        host = 'Host@backend'
+        mock_conf.rpc_backend = 'zmq'
+        # expected_host = 'Host'
+        expected_host = volume_utils.extract_host(host, 'host')
+        self.assertEqual(expected_host,
+                         volume_utils.get_volume_rpc_host(host))
+        mock_conf.rpc_backend = 'rabbit'
+        # default level is 'backend'
+        # check if host with backend is returned
+        # expected_host = 'Host@backend'
+        expected_host = volume_utils.extract_host(host)
+        self.assertEqual(expected_host,
+                         volume_utils.get_volume_rpc_host(host))
+
+    @mock.patch('cinder.volume.utils.CONF')
+    def test_get_volume_rpc_topic(self, mock_conf):
+        host = 'Host@backend'
+        mock_conf.rpc_backend = 'zmq'
+        expected_topic = 'cinder-volume@backend'
+        self.assertEqual(expected_topic,
+                         volume_utils.get_volume_rpc_topic(host))
+        mock_conf.rpc_backend = 'rabbit'
+        expected_topic = 'cinder-volume'
+        self.assertEqual(expected_topic,
+                         volume_utils.get_volume_rpc_topic(host))
+
     def test_append_host(self):
         host = 'Host'
         pool = 'Pool'

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -76,14 +76,19 @@ class VolumeAPI(object):
         self.client = rpc.get_client(target, '1.23', serializer=serializer)
 
     def _get_cctxt(self, host, version=None):
-        if utils.only_hostname_required():
-            new_host = utils.extract_host(host, 'host')
-        else:
-            new_host = utils.extract_host(host)
+        new_host = utils.get_volume_rpc_host(host)
+        new_topic = utils.get_volume_rpc_topic(host)
         if version:
-            cctxt = self.client.prepare(server=new_host, version=version)
+            if new_topic:
+                cctxt = self.client.prepare(server=new_host, topic=new_topic,
+                                            version=version)
+            else:
+                cctxt = self.client.prepare(server=new_host, version=version)
         else:
-            cctxt = self.client.prepare(server=new_host)
+            if new_topic:
+                cctxt = self.client.prepare(server=new_host, topic=new_topic)
+            else:
+                cctxt = self.client.prepare(server=new_host)
         return cctxt
 
     def create_consistencygroup(self, ctxt, group, host):

--- a/cinder/volume/utils.py
+++ b/cinder/volume/utils.py
@@ -502,6 +502,28 @@ def extract_host(host, level='backend', default_pool_name=False):
             return None
 
 
+def get_volume_rpc_host(host):
+    if only_hostname_required():
+        # ZeroMQ RPC driver requires only the hostname.
+        # So, return just that.
+        return extract_host(host, 'host')
+    return extract_host(host)
+
+
+def get_volume_rpc_topic(host, topic=None):
+    # In AMQP, backend was appended to hostname which helped distinguish
+    # multiple backends. This didn't cause any problems as the node
+    # hostname wasn't used; rather the AMQP broker hostname was used.
+    if only_hostname_required():
+        # ZeroMQ RPC driver requires only the hostname.
+        # So, distinguish multilple backends by appending backend to topic
+        pool_sep = '#'
+        backend_sep = '@'
+        backend = host.split(pool_sep)[0].split(backend_sep)[1]
+        topic = backend_sep.join([topic, backend])
+    return topic
+
+
 def append_host(host, pool):
     """Encode pool into host info."""
     if not host or not pool:


### PR DESCRIPTION
Support ZeroMQ messaging driver in cinder multibackend

ZeroMQ driver requires hostname for message delivery as
there is no broker inbetween;
To distinguish multiple backends append the backend to the topic.

Closes-Bug: #JBS-72