### PR TITLE
Merge Monitoring Changes of cinder to JioCloud Cinder branch

### DIFF
--- a/cinder/api/metricutil.py
+++ b/cinder/api/metricutil.py
@@ -1,0 +1,62 @@
+'''
+Created on Jan 29, 2016
+
+@author: souvik
+'''
+from metrics.ThreadLocalMetrics import ThreadLocalMetrics, ThreadLocalMetricsFactory
+from oslo_log import log as logging
+LOG = logging.getLogger(__name__)
+
+class MetricUtil(object):
+    '''
+    Metric Utility class to put and fetch request scoped metrics in cinder api
+    '''
+    METRICS_OBJECT = "metrics_object"
+    def __init__(self):
+        '''
+        Constructor for Metric Utils. 
+        '''
+        
+    def initialize_thread_local_metrics(self, request):
+        
+        try:
+            metrics = self.fetch_thread_local_metrics()
+        except AttributeError:
+            service_log_path = self.__get_service_log_path()
+            marketplace_id = self.__get_marketplace_id()
+            prognam_name = self.__get_prognam_name()
+            # TODO: Thread local metrics should be application context object or a singleton
+            metrics = ThreadLocalMetricsFactory(service_log_path).with_marketplace_id(marketplace_id)\
+                            .with_program_name(prognam_name).create_metrics()
+            self.__add_details_from_request(request, metrics)
+        return metrics
+    
+    def __add_details_from_request(self, request, metrics):
+        context = request.environ.get('cinder.context')
+        metrics.add_property("TenantId", context.project_id)
+        metrics.add_property("RemoteAddress", context.remote_address)
+        metrics.add_property("RequestId", context.request_id)
+        metrics.add_property("PathInfo", request.environ.get('PATH_INFO'))
+        # Project id is not provided to protect the identity of the user
+        # Domain is not provided is it is not used
+        #metrics.add_property("UserId", context.user_id)
+             
+    def fetch_thread_local_metrics(self):
+        return ThreadLocalMetrics.get()
+        
+    def __get_service_log_path(self):
+        # TODO: Get this from config where the rest of the logging is defined
+        return "/var/log/cinder/service_log"
+    
+    def __get_marketplace_id(self):
+        # TODO:Get this from from config/keystone
+        return "IDC1"
+    
+    def __get_prognam_name(self):
+        # TODO: Get this from Config
+        return "CinderAPI"
+    
+    def closeMetrics(self, request):
+        metrics = self.fetch_thread_local_metrics()
+        metrics.close()
+

--- a/cinder/api/v2/volumes.py
+++ b/cinder/api/v2/volumes.py
@@ -37,11 +37,8 @@ from cinder import utils
 from cinder import volume as cinder_volume
 from cinder.volume import utils as volume_utils
 from cinder.volume import volume_types
-<<<<<<< 59e528fc36b2ed3804ec1bc5fba7c136867153fb
 from cinder.api.v2 import cache_volumes as volume_cache
-=======
 from metrics.Metrics import Metrics, Unit
->>>>>>> Working method
 
 
 LOG = logging.getLogger(__name__)

--- a/cinder/api/v2/volumes.py
+++ b/cinder/api/v2/volumes.py
@@ -11,11 +11,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from metrics.ThreadLocalMetrics import ThreadLocalMetrics
+from metrics.Metrics import Metrics
 
 """The volumes api."""
 
 
 import ast
+from time import time
 
 from oslo_log import log as logging
 from oslo_utils import uuidutils
@@ -34,7 +37,11 @@ from cinder import utils
 from cinder import volume as cinder_volume
 from cinder.volume import utils as volume_utils
 from cinder.volume import volume_types
+<<<<<<< 59e528fc36b2ed3804ec1bc5fba7c136867153fb
 from cinder.api.v2 import cache_volumes as volume_cache
+=======
+from metrics.Metrics import Metrics, Unit
+>>>>>>> Working method
 
 
 LOG = logging.getLogger(__name__)
@@ -237,13 +244,17 @@ class VolumeController(wsgi.Controller):
                 filters[k] = ast.literal_eval(v)
             except (ValueError, SyntaxError):
                 LOG.debug('Could not evaluate value %s, assuming string', v)
-
+        
+        start_time = time()
         volumes = self.volume_api.get_all(context, marker, limit,
                                           sort_keys=sort_keys,
                                           sort_dirs=sort_dirs,
                                           filters=filters,
                                           viewable_admin_meta=True)
-
+        end_time = time()
+        time_in_millis = int((end_time - start_time)*1000)
+        metrics = ThreadLocalMetrics.get()
+        metrics.add_time("mysql-get-all-volumes", time_in_millis, Unit.MILLIS)
         volumes = [dict(vol.iteritems()) for vol in volumes]
 
         for volume in volumes:

--- a/cinder/backup/drivers/sbs.py
+++ b/cinder/backup/drivers/sbs.py
@@ -822,7 +822,7 @@ class SBSBackupDriver(driver.BackupDriver):
 
         if conn != None:
             try:
-                bucket = self._get_bucket(conn, backup['container')
+                bucket = self._get_bucket(conn, backup['container'])
             except Exception as e:
                 pass
         else:

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -421,6 +421,7 @@ class API(base.Base):
         if filters:
             LOG.debug("Searching by: %s.", six.text_type(filters))
 
+       
         if context.is_admin and allTenants:
             # Need to remove all_tenants to pass the filtering below.
             del filters['all_tenants']

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ oslo.i18n<1.6.0,>=1.5.0 # Apache-2.0
 oslo.vmware<0.12.0,>=0.11.1 # Apache-2.0
 boto>=2.38.0
 filechunkio>=1.6
+metrics>=0.1


### PR DESCRIPTION
Tested with the new changes

vagrant@cinder:~/workspace/cinder$ time cinder list
+--------------------------------------+----------------+-----------------------------------------------------+------+-------------+----------+-------------+
|                  ID                  |     Status     |                         Name                        | Size | Volume Type | Bootable | Attached to |
+--------------------------------------+----------------+-----------------------------------------------------+------+-------------+----------+-------------+
| 7518e108-a3e8-443f-a367-bff4034a2ec5 |   available    |                         None                        |  1   |     None    |  false   |             |
| 75cd6044-1bbc-41b8-b7cc-ba8a40992521 |   available    |                         None                        |  1   |     None    |  false   |             |
| 85197401-0706-40a9-88e1-3ddb448508fd |   available    |                         None                        |  1   |     None    |  false   |             |
| 9735d7a0-ff4a-4758-97cd-255f695922a5 |   available    |                         None                        |  1   |     None    |  false   |             |
| 98cabab8-6456-4c3c-98b0-d0fe3218926d |   available    |                         None                        |  1   |     None    |  false   |             |
| b14969be-f413-4b35-adc7-69adafdfb2ef |   available    |                         None                        |  1   |     None    |  false   |             |
| b2982c26-d560-4289-98d6-d65c33c02a7c |   available    |                         None                        |  1   |     None    |  false   |             |
| c1365811-c676-4cc0-b7a6-058eb1d038c6 |   available    |                         None                        |  1   |     None    |  false   |             |
| d968f4cd-0fca-4389-8002-c98e95ec5a04 | error_deleting |                         None                        |  1   |     None    |  false   |             |
| dd4065ef-70ad-424c-9dfc-5d0fe2a2cf98 |   available    | restore_backup_ef5e74cd-34de-48bf-9c2b-4fd64a9c9f79 |  2   |     None    |  false   |             |
+--------------------------------------+----------------+-----------------------------------------------------+------+-------------+----------+-------------+

real    0m0.893s
user    0m0.164s
sys     0m0.040s


Logs 

2016-02-16 13:45:39.449 6373 DEBUG keystoneclient.session [-] RESP: [300] Date: Tue, 16 Feb 2016 13:45:39 GMT Vary: X-Auth-Token Content-Length: 587 Content-Type: application/json Server: Apache/2.4.7 (Ubuntu)
RESP BODY: {"versions": {"values": [{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v3.4", "links": [{"href": "http://devstack:35357/v3/", "rel": "self"}]}, {"status": "stable", "updated": "2014-04-17T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v2.0+json"}], "id": "v2.0", "links": [{"href": "http://devstack:35357/v2.0/", "rel": "self"}, {"href": "http://docs.openstack.org/", "type": "text/html", "rel": "describedby"}]}]}}
 _http_log_response /usr/lib/python2.7/dist-packages/keystoneclient/session.py:223
2016-02-16 13:45:39.450 6373 DEBUG keystoneclient.auth.identity.v2 [-] Making authentication request to http://devstack:35357/v2.0/tokens get_auth_ref /usr/lib/python2.7/dist-packages/keystoneclient/auth/identity/v2.py:76
2016-02-16 13:45:39.521 6373 DEBUG keystoneclient.session [-] REQ: curl -g -i -X GET http://devstack:35357/v3/auth/tokens -H "X-Subject-Token: {SHA1}244cea9248374cbb4e105d6ca8129154ec96db4c" -H "User-Agent: python-keystoneclient" -H "Accept: application/json" -H "X-Auth-Token: {SHA1}519d13a4d75fc17228ec189eca3c99342c66bf31" _http_log_request /usr/lib/python2.7/dist-packages/keystoneclient/session.py:195
2016-02-16 13:45:39.583 6373 DEBUG keystoneclient.session [-] RESP: [200] Content-Length: 4074 X-Subject-Token: {SHA1}244cea9248374cbb4e105d6ca8129154ec96db4c Vary: X-Auth-Token Server: Apache/2.4.7 (Ubuntu) Date: Tue, 16 Feb 2016 13:45:39 GMT Content-Type: application/json x-openstack-request-id: req-a3cc555e-611b-454d-87a9-7e3ebf6f78e5
RESP BODY: {"token": {"methods": ["password", "token"], "roles": [{"id": "cee5bab131fd46e79a4c7be490033118", "name": "admin"}], "expires_at": "2016-02-16T14:45:39.000000Z", "project": {"domain": {"id": "default", "name": "Default"}, "id": "1ba79c89032245f38c42bb813a5c2e92", "name": "admin"}, "catalog": "<removed>", "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id": "07223e4611dc47ddae0da6811710cbb3", "name": "admin"}, "audit_ids": ["2hlNaDVDQzSrimwDVQPsfg"], "issued_at": "2016-02-16T13:45:39.345206"}}
 _http_log_response /usr/lib/python2.7/dist-packages/keystoneclient/session.py:223
2016-02-16 13:45:39.586 6373 DEBUG cinder.openstack.common.fileutils [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] Reloading cached file /etc/cinder/policy.json read_cached_file /usr/local/lib/python2.7/dist-packages/cinder/openstack/common/fileutils.py:64
2016-02-16 13:45:39.588 6373 DEBUG cinder.openstack.common.policy [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] Reloaded policy file: /etc/cinder/policy.json _load_policy_file /usr/local/lib/python2.7/dist-packages/cinder/openstack/common/policy.py:296
2016-02-16 13:45:39.705 6373 INFO cinder.api.openstack.wsgi [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] GET http://cinder:8776/v2/1ba79c89032245f38c42bb813a5c2e92/volumes/detail
2016-02-16 13:45:39.706 6373 DEBUG cinder.api.openstack.wsgi [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] Empty body provided in request get_body /usr/local/lib/python2.7/dist-packages/cinder/api/openstack/wsgi.py:871
2016-02-16 13:45:39.868 6373 DEBUG oslo_db.sqlalchemy.session [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] MySQL server mode set to STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,TRADITIONAL,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION _check_effective_sql_mode /usr/lib/python2.7/dist-packages/oslo_db/sqlalchemy/session.py:513
2016-02-16 13:45:39.889 6373 INFO cinder.api.openstack.wsgi [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] http://cinder:8776/v2/1ba79c89032245f38c42bb813a5c2e92/volumes/detail returned with HTTP 200
2016-02-16 13:45:39.890 6373 INFO service.log [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] ===================================================================
StartTime=1455630339.71
EndTime=2016-02-16 13:45:39
Time=183 ms
OperationName=detail
ResponseCode=200
RemoteAddress=172.28.128.5
PathInfo=/1ba79c89032245f38c42bb813a5c2e92/volumes/detail
HostName=cinder
PID=6373
TenantId=1ba79c89032245f38c42bb813a5c2e92
RequestId=req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a
ProgramName=CinderAPI
MarketplaceId=IDC1
Timing=mysql-get-all-volumes=173 ms,
Counters=fault=0,success=1,error=0,
EOE
2016-02-16 13:45:39.896 6373 INFO eventlet.wsgi.server [req-6334bbbb-8ce3-4835-80c4-8f14841dbd9a 07223e4611dc47ddae0da6811710cbb3 1ba79c89032245f38c42bb813a5c2e92 - - -] 172.28.128.5 - - [16/Feb/2016 13:45:39] "GET /v2/1ba79c89032245f38c42bb813a5c2e92/volumes/detail HTTP/1.1" 200 10473 0.470105
