### PR TITLE
Handle race between snap delete and volume delete

### DIFF
--- a/cinder/volume/drivers/rbd.py
+++ b/cinder/volume/drivers/rbd.py
@@ -562,8 +562,13 @@ class RBDDriver(driver.VolumeDriver):
         backup_snaps = self._get_backup_snaps(rbd_image)
         if backup_snaps:
             ctxt = context.elevated()
+            backup = None
             for snap in backup_snaps:
-                backup = self.db.backup_get(ctxt, snap['backup_id'])
+                try:
+                    backup = self.db.backup_get(ctxt, snap['backup_id'])
+                except exception.NotFound:
+                    backup = None
+                    pass
                 if backup and backup['status'] == 'creating':
                     LOG.info("Volume %s has backup %s in creating state" %
                              (volume_name, backup['id']))


### PR DESCRIPTION
If a volume is being deleted, it tries to clear the
snapshots by fetching a list from ceph cluster. A parallel snapshot
delete might also remove the same. Make sure we do
not error out if the snapshot was removed from the
db

Signed-off-by: shishir gowda <shishir.gowda@ril.com>