### PR TITLE
cinder volume HA

### DIFF
--- a/cinder/cmd/volume.py
+++ b/cinder/cmd/volume.py
@@ -55,6 +55,13 @@ host_opt = cfg.StrOpt('backend_host', help='Backend override of host value.',
 cfg.CONF.register_cli_opt(host_opt)
 CONF = cfg.CONF
 
+zmq_opts = [
+    cfg.StrOpt('rpc_zmq_vol_vip', default=None,
+               sample_default='localhost',
+               help='vip of this node. Must be a valid hostname'),
+]
+CONF.register_opts(zmq_opts)
+
 
 def main():
     objects.register_all()

--- a/cinder/service.py
+++ b/cinder/service.py
@@ -32,6 +32,7 @@ import osprofiler.notifier
 from osprofiler import profiler
 import osprofiler.web
 
+from cinder.constants import CINDER_VOLUME
 from cinder import context
 from cinder import db
 from cinder import exception
@@ -154,6 +155,8 @@ class Service(service.Service):
         LOG.debug("Creating RPC server for service %s", self.topic)
 
         target = messaging.Target(topic=self.topic, server=self.host)
+        if self.binary == CINDER_VOLUME and CONF.rpc_zmq_vol_vip:
+            CONF.rpc_zmq_host = CONF.rpc_zmq_vol_vip
         endpoints = [self.manager]
         endpoints.extend(self.manager.additional_endpoints)
         serializer = objects_base.CinderObjectSerializer()


### PR DESCRIPTION
commit 2e22f0a3e6e64faef8d457060961e46a7ca46a9 removed the coupling
between volume and and its host. So, volume requests were sent to the
active volume service. We are running volume services in
active-passive mode with a VIP associated with the active one.
The volume service should listen on this VIP.
So, set the volume rpc host to this VIP.

Note - This requires a new config option 'rpc_zmq_vol_vip'
       to be set with volume vip value. This option and patch can be 
       removed after we move to active active configuration.

Testing done in DevTest env:
* Tested the patch with volume, scheduler and api services.
* Tested that the scheduler was able to send volume create requests to
  volume service
* Tested that the api was able to send delete volume delete requests to
  volume service

Closes-Bug: #JBS-105