### PR TITLE
"volume service is down" warnings misinterpreted

### DIFF
--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -483,7 +483,7 @@ class HostManager(object):
         for service in volume_services:
             host = service['host']
             if not utils.service_is_up(service):
-                LOG.warn(_LW("volume service is down. (host: %s)") % host)
+                LOG.debug("volume service is down. (host: %s)" % host)
                 continue
             capabilities = self.service_states.get(host, None)
             if capabilities is None:

--- a/cinder/tests/scheduler/test_host_manager.py
+++ b/cinder/tests/scheduler/test_host_manager.py
@@ -240,6 +240,7 @@ class HostManagerTestCase(test.TestCase):
         _mock_service_is_up.return_value = True
         _mock_warning = mock.Mock()
         host_manager.LOG.warn = _mock_warning
+        host_manager.LOG.debug = _mock_warning
 
         # Get all states
         self.host_manager.get_all_host_states(context)


### PR DESCRIPTION
We run cinder-volume service in active passive mode. There were "volume
service is down" warning messages in cinder-volume logs about the
passive volume service. This led to misinterpretation that there were
problems with the volume service.

So, this patch decreased the log level of this message to 'DEBUG'.
We should switch back once we have cinder-volume service running in
active-active mode as this message is a useful health check indicator.

Closes-Bug: #JBS-108