### PR TITLE
JBS-109: remove db entry for snapshot delete in elevated context

### DIFF
--- a/cinder/backup/drivers/sbs.py
+++ b/cinder/backup/drivers/sbs.py
@@ -879,7 +879,7 @@ class SBSBackupDriver(driver.BackupDriver):
             if ret == False:
                 LOG.error("Deleting backup %s from DSS failed" % backup['id'])
             self._delete_snap_from_src(backup)
-            self.db.backup_destroy(self.context, backup['id'])
+            self.db.backup_destroy(self.context.elevated(), backup['id'])
             last_backup = backup
             i = i+1
         LOG.debug("Last backup deleted %s" % last_backup['id'])


### PR DESCRIPTION
This fails when non-admin triggers snapshot delete

Signed-off-by: shishir gowda <shishir.gowda@ril.com>