### PR TITLE
Cinder policy checks are no more required

### DIFF
--- a/cinder/policy.py
+++ b/cinder/policy.py
@@ -25,11 +25,20 @@ CONF = cfg.CONF
 
 _ENFORCER = None
 
+class DisabledEnforcer():
+    def enforce(self, *args, **kwargs):
+        """Disabled policy engine in Cinder
+
+        Policy enforcement is no more done at cinder for SBS.
+        Its now done by IAM in keystone.
+        So, this method is just a  pass-through.
+        """
+        return True
 
 def init():
     global _ENFORCER
     if not _ENFORCER:
-        _ENFORCER = policy.Enforcer()
+        _ENFORCER = DisabledEnforcer()
 
 
 def enforce_action(context, action):


### PR DESCRIPTION
As we all know, we've integrated with the new policy based IAM.
We no more need policy checks at cinder side. So, disable it.

Closes-Bug: #JBS-139