### PR TITLE
Volume Creaton time is GMT and not IST

### DIFF
--- a/cinder/db/sqlalchemy/api.py
+++ b/cinder/db/sqlalchemy/api.py
@@ -1145,7 +1145,7 @@ def finish_volume_migration(context, src_vol_id, dest_vol_id):
 @_retry_on_deadlock
 def volume_destroy(context, volume_id):
     session = get_session()
-    now = timeutils.utcnow()
+    now = dt.datetime.now()
     with session.begin():
         model_query(context, models.Volume, session=session).\
             filter_by(id=volume_id).\
@@ -3270,7 +3270,7 @@ def backup_destroy(context, backup_id):
         filter_by(id=backup_id).\
         update({'status': 'deleted',
                 'deleted': True,
-                'deleted_at': timeutils.utcnow(),
+                'deleted_at': dt.datetime.now(),
                 'updated_at': literal_column('updated_at')})
 
 

--- a/cinder/db/sqlalchemy/models.py
+++ b/cinder/db/sqlalchemy/models.py
@@ -19,6 +19,8 @@
 SQLAlchemy models for cinder data.
 """
 
+from datetime import datetime
+
 from oslo_config import cfg
 from oslo_db.sqlalchemy import models
 from oslo_utils import timeutils
@@ -112,6 +114,8 @@ class Volume(BASE, CinderBase):
     __tablename__ = 'volumes'
     id = Column(String(36), primary_key=True)
     _name_id = Column(String(36))  # Don't access/modify this directly!
+    created_at = Column(DateTime, default=lambda: datetime.now())
+    updated_at = Column(DateTime, onupdate=lambda: datetime.now())
 
     @property
     def name_id(self):
@@ -505,6 +509,8 @@ class Backup(BASE, CinderBase):
     """Represents a backup of a volume to Swift."""
     __tablename__ = 'backups'
     id = Column(String(36), primary_key=True)
+    created_at = Column(DateTime, default=lambda: datetime.now())
+    updated_at = Column(DateTime, onupdate=lambda: datetime.now())
 
     @property
     def name(self):


### PR DESCRIPTION
Updated CRUD operations to store timestamps in IST

Test cases verified:
* Verified that timestamps are in IST in below CLI operations,
  "create, show, delete, backup-create, backup-show, backup-delete"

Note:
* This is not a cinder wide change but just limited to volumes and backups
* Cinder is not timezone aware

Closes-Bug: #JBS-157