### PR TITLE
Storing Volume Id in Snapshot Database

### DIFF
--- a/cinder/backup/api.py
+++ b/cinder/backup/api.py
@@ -270,7 +270,7 @@ class API(base.Base):
                          "backup %(backup_id)s"),
                      {'size': vol_size, 'backup_id': backup_id},
                      context=context)
-            volume = self.volume_api.create(context, vol_size, name, description)
+            volume = self.volume_api.create(context, vol_size, name, description, backup_id=backup_id)
             volume_id = volume['id']
 
             while True:

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -162,7 +162,7 @@ class API(base.Base):
                availability_zone=None, source_volume=None,
                scheduler_hints=None,
                source_replica=None, consistencygroup=None,
-               cgsnapshot=None, multiattach=False,volume_from_cache=None):
+               cgsnapshot=None, multiattach=False,volume_from_cache=None, backup_id=None):
 
         # NOTE(jdg): we can have a create without size if we're
         # doing a create from snap or volume.  Currently
@@ -239,6 +239,7 @@ class API(base.Base):
             'cgsnapshot': cgsnapshot,
             'multiattach': multiattach,
             'volume_from_cache':volume_from_cache,
+            'backup_id':backup_id,
         }
         try:
             if cgsnapshot:


### PR DESCRIPTION
Tested


ubuntu@compute2:/usr/lib/python2.7/dist-packages$ curl -X GET -H "Accept-Encoding: identity" -H "User-Agent: curl/7.35.0" -H "Content-Type: application/json" "http://10.140.12.215:8788/services/Cloud/?TokenId=ca4b8ca83a1b482e90046ad4222a3db1&ProjectId=82deb70d37c14d44a25b518e829802ca&UserId=b5c7d23859154bc182bab1f303dc0a20&RequestId=req-baa52567-8cb8-4dc4-849c-08e738a4591f&Action=CreateVolume&SnapshotId=48fa281f-4ef2-42db-8e18-d26ef9509a2c"
<CreateVolumeResponse xmlns="http://compute.jiocloudservices.com/doc/2016-03-01/">
  <requestId>req-baa52567-8cb8-4dc4-849c-08e738a4591f</requestId>
  <status>creating</status>
  <volumeId>8ed739db-d609-48a5-894e-136dfbdab940</volumeId>
  <attachmentSet/>
  <snapshotId>48fa281f-4ef2-42db-8e18-d26ef9509a2c</snapshotId>
  <createTime>2016-03-23T20:57:51.000000</createTime>
  <size>1</size>
</CreateVolumeResponse>
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ 
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ curl -X GET -H "Accept-Encoding: identity" -H "User-Agent: curl/7.35.0" -H "Content-Type: application/json" "http://10.140.12.215:8788/services/Cloud/?TokenId=ca4b8ca83a1b482e90046ad4222a3db1&ProjectId=82deb70d37c14d44a25b518e829802ca&UserId=b5c7d23859154bc182bab1f303dc0a20&RequestId=req-baa52567-8cb8-4dc4-849c-08e738a4591f&Action=DescribeVolumes&VolumeId=8ed739db-d609-48a5-894e-136dfbdab940"
<DescribeVolumesResponse xmlns="http://compute.jiocloudservices.com/doc/2016-03-01/">
  <requestId>req-baa52567-8cb8-4dc4-849c-08e738a4591f</requestId>
  <volumeSet>
    <item>
      <status>available</status>
      <volumeId>8ed739db-d609-48a5-894e-136dfbdab940</volumeId>
      <attachmentSet/>
      <snapshotId>48fa281f-4ef2-42db-8e18-d26ef9509a2c</snapshotId>
      <createTime>2016-03-23T20:57:51.000000</createTime>
      <size>1</size>
    </item>
  </volumeSet>
</DescribeVolumesResponse>
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ 
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ 
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ 
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ curl -X GET -H "Accept-Encoding: identity" -H "User-Agent: curl/7.35.0" -H "Content-Type: application/json" "http://10.140.12.215:8788/services/Cloud/?TokenId=ca4b8ca83a1b482e90046ad4222a3db1&ProjectId=82deb70d37c14d44a25b518e829802ca&UserId=b5c7d23859154bc182bab1f303dc0a20&RequestId=req-baa52567-8cb8-4dc4-849c-08e738a4591f&Action=CreateVolume&Size=1"
<CreateVolumeResponse xmlns="http://compute.jiocloudservices.com/doc/2016-03-01/">
  <requestId>req-baa52567-8cb8-4dc4-849c-08e738a4591f</requestId>
  <status>creating</status>
  <volumeId>e58fb9ee-b42b-4102-9e21-6c51933491b7</volumeId>
  <attachmentSet/>
  <snapshotId/>
  <createTime>2016-03-23T20:58:59.000000</createTime>
  <size>1</size>
</CreateVolumeResponse>
ubuntu@compute2:/usr/lib/python2.7/dist-packages$ curl -X GET -H "Accept-Encoding: identity" -H "User-Agent: curl/7.35.0" -H "Content-Type: application/json" "http://10.140.12.215:8788/services/Cloud/?TokenId=ca4b8ca83a1b482e90046ad4222a3db1&ProjectId=82deb70d37c14d44a25b518e829802ca&UserId=b5c7d23859154bc182bab1f303dc0a20&RequestId=req-baa52567-8cb8-4dc4-849c-08e738a4591f&Action=DescribeVolumes&VolumeId=e58fb9ee-b42b-4102-9e21-6c51933491b7"
<DescribeVolumesResponse xmlns="http://compute.jiocloudservices.com/doc/2016-03-01/">
  <requestId>req-baa52567-8cb8-4dc4-849c-08e738a4591f</requestId>
  <volumeSet>
    <item>
      <status>available</status>
      <volumeId>e58fb9ee-b42b-4102-9e21-6c51933491b7</volumeId>
      <attachmentSet/>
      <snapshotId/>
      <createTime>2016-03-23T20:58:59.000000</createTime>
      <size>1</size>
    </item>
  </volumeSet>
</DescribeVolumesResponse>

mysql> select id, snapshot_id from volumes where id = '8ed739db-d609-48a5-894e-136dfbdab940' or id = 'e58fb9ee-b42b-4102-9e21-6c51933491b7';
+--------------------------------------+--------------------------------------+
| id                                   | snapshot_id                          |
+--------------------------------------+--------------------------------------+
| 8ed739db-d609-48a5-894e-136dfbdab940 | 48fa281f-4ef2-42db-8e18-d26ef9509a2c |
| e58fb9ee-b42b-4102-9e21-6c51933491b7 | NULL                                 |
+--------------------------------------+--------------------------------------+
2 rows in set (0.00 sec)


