### PR TITLE
Shared round robin scheduling

### DIFF
--- a/cinder/backup/rpcapi.py
+++ b/cinder/backup/rpcapi.py
@@ -22,6 +22,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 import oslo_messaging as messaging
 
+from cinder.common import round_robin_scheduler as rrs
 from cinder import rpc
 
 
@@ -47,7 +48,7 @@ class BackupAPI(object):
         self.client = rpc.get_client(target, '1.0')
 
     def _get_cctxt(self):
-        return self.client.prepare()
+        return self.client.prepare(server=rrs.get_next_backup_host())
 
     def create_backup(self, ctxt, host, backup_id, volume_id, orig_status):
         LOG.debug("create_backup in rpcapi backup_id %s", backup_id)

--- a/cinder/cmd/api.py
+++ b/cinder/cmd/api.py
@@ -35,6 +35,7 @@ i18n.enable_lazy()
 
 # Need to register global_opts
 from cinder.common import config  # noqa
+from cinder.common import round_robin_scheduler as rrs
 from cinder import rpc
 from cinder import service
 from cinder import utils
@@ -52,6 +53,7 @@ def main():
     utils.monkey_patch()
 
     rpc.init(CONF)
+    rrs.init()
     launcher = service.process_launcher()
     server = service.WSGIService('osapi_volume')
     launcher.launch_service(server, workers=server.workers)

--- a/cinder/common/round_robin_scheduler.py
+++ b/cinder/common/round_robin_scheduler.py
@@ -1,0 +1,62 @@
+# Copyright 2016 Reliance Jio Infocomm Ltd.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from cinder.constants import CINDER_BACKUP
+from cinder import context
+from cinder import db
+from cinder.db.sqlalchemy import models
+from cinder import exception
+from cinder import objects
+from cinder import utils
+
+
+def init():
+    ctxt = context.get_admin_context()
+    try:
+        db.service_sequence_get(ctxt, CINDER_BACKUP)
+    except exception.ServiceNotFound:
+        db.service_sequence_create(ctxt, {'service' : CINDER_BACKUP})
+    
+
+def get_next_backup_host():
+    ctxt = context.get_admin_context()
+    services = db.service_get_all_by_topic(ctxt, CINDER_BACKUP, disabled=False)
+    hostList = [s['host'] for s in services]
+    hostList.sort()
+    MAX_RETRIES = 10
+    retry = 1
+    updated = False
+    while retry < MAX_RETRIES and not updated:
+        service = db.service_sequence_get(ctxt, CINDER_BACKUP)
+        index = service['index']
+        hostsCount = len(hostList)
+        if index < hostsCount:
+            new_index = index + 1
+        else:
+            new_index = (index % hostsCount) + 1
+        expected_attrs = {'service' : CINDER_BACKUP, 'index' : index}
+        new_attrs = {'index' : new_index}
+        updated = db.conditional_update(ctxt, models.ServicesSequences,
+                                        new_attrs, expected_attrs)
+        if updated:
+            # list index starts with zero so offset 1
+            host = hostList[new_index - 1]
+            srv_ref = db.service_get_by_host_and_topic(
+                ctxt, host, CINDER_BACKUP)
+            if utils.service_is_up(srv_ref):
+                return host
+        retry = retry + 1
+    raise exception.ServiceNotFound(service_id=CINDER_BACKUP)

--- a/cinder/constants.py
+++ b/cinder/constants.py
@@ -17,3 +17,4 @@
 
 
 CINDER_VOLUME = "cinder-volume"
+CINDER_BACKUP = "cinder-backup"

--- a/cinder/db/api.py
+++ b/cinder/db/api.py
@@ -133,6 +133,28 @@ def service_update(context, service_id, values):
 ###################
 
 
+def service_sequence_create(context, values):
+    """Create a service sequence from the values dictionary."""
+    return IMPL.service_sequence_create(context, values)
+
+
+def service_sequence_update(context, service, values):
+    """Update a service sequence from the values dictionary.
+
+    Raises NotFound if service does not exist.
+
+    """
+    return IMPL.service_sequence_update(context, service, values)
+
+
+def service_sequence_get(context, service):
+    """Get a service sequence or raise if it does not exist."""
+    return IMPL.service_sequence_get(context, service)
+
+
+###############
+
+
 def iscsi_target_count_by_host(context, host):
     """Return count of export devices."""
     return IMPL.iscsi_target_count_by_host(context, host)
@@ -985,3 +1007,37 @@ def driver_initiator_data_update(context, initiator, namespace, updates):
 def driver_initiator_data_get(context, initiator, namespace):
     """Query for an DriverPrivateData that has the specified key"""
     return IMPL.driver_initiator_data_get(context, initiator, namespace)
+
+
+class Condition(object):
+    """Class for normal condition values for conditional_update."""
+    def __init__(self, value, field=None):
+        self.value = value
+        # Field is optional and can be passed when getting the filter
+        self.field = field
+
+    def get_filter(self, model, field=None):
+        return IMPL.condition_db_filter(model, self._get_field(field),
+                                        self.value)
+
+    def _get_field(self, field=None):
+        # We must have a defined field on initialization or when called
+        field = field or self.field
+        if not field:
+            raise ValueError(_('Condition has no field.'))
+        return field
+
+
+def conditional_update(context, model, values, expected_values, filters=(),
+                       include_deleted='no', project_only=False):
+    """Compare-and-swap conditional update.
+
+       Update will only occur in the DB if conditions are met.
+
+       :param values: Dictionary of key-values to update in the DB.
+       :param expected_values: Dictionary of conditions that must be met
+                               for the update to be executed.
+       :returns number of db rows that were updated
+    """
+    return IMPL.conditional_update(context, model, values, expected_values,
+                                   filters, include_deleted, project_only)

--- a/cinder/db/sqlalchemy/models.py
+++ b/cinder/db/sqlalchemy/models.py
@@ -72,6 +72,14 @@ class Service(BASE, CinderBase):
     modified_at = Column(DateTime)
 
 
+class ServicesSequences(BASE, CinderBase):
+    """Represents the sequence in which LB happens between services."""
+
+    __tablename__ = 'services_sequences'
+    service = Column(String(255), primary_key=True)
+    index = Column(Integer, nullable=False, default=0)
+
+
 class ConsistencyGroup(BASE, CinderBase):
     """Represents a consistencygroup."""
     __tablename__ = 'consistencygroups'


### PR DESCRIPTION
So far, every c-api process maintained its own round robin sequence  for c-bak service.
This patch attempts to create a common round robin sequence
that is shared between multiple c-api processes in multiple nodes.

Closes-Bug: #JBS-78