### PR TITLE
JBS-183: Close rbd_image if volume has backups in creation state

### DIFF
--- a/cinder/volume/drivers/rbd.py
+++ b/cinder/volume/drivers/rbd.py
@@ -667,11 +667,10 @@ class RBDDriver(driver.VolumeDriver):
             parent = None
 
             # Ensure any backup snapshots are deleted
-            self._delete_backup_snaps(rbd_image, volume_name, context)
-
             # If the volume has non-clone snapshots this delete is expected to
             # raise VolumeIsBusy so do so straight away.
             try:
+                self._delete_backup_snaps(rbd_image, volume_name, context)
                 snaps = rbd_image.list_snaps()
                 for snap in snaps:
                     if snap['name'].endswith('.clone_snap'):


### PR DESCRIPTION
If a volume has a backup in creation state, we error out delete
with a volume busy error. By not catching the exception, the
rbd image would not be closed, leading to rbd driver to crash/hang.

Signed-off-by: shishir gowda <shishir.gowda@ril.com>