### PR TITLE
JBS-192: Update 1st snapshot timestamp to IST

### DIFF
--- a/cinder/backup/drivers/sbs.py
+++ b/cinder/backup/drivers/sbs.py
@@ -54,6 +54,7 @@ from cinder import exception
 from cinder.i18n import _, _LE, _LI, _LW
 from cinder import utils
 import cinder.volume.drivers.rbd as rbd_driver
+import datetime as dt
 
 try:
     import rbd
@@ -636,7 +637,7 @@ class SBSBackupDriver(driver.BackupDriver):
                 raise exception.BackupOperationError(msg)
 
         #make sure snap is newer than base
-        now = timeutils.utcnow()
+        now = dt.datetime.now()
         self.db.backup_update(self.context, backup_id,
 			      {'created_at': now})
         self.db.backup_update(self.context, backup_id,


### PR DESCRIPTION
We update 1st snapshot created_at time, so that it is higher
than the base snapshot.

With changes in timestamp to IST, the 1st snapshot was getting
UTC, which would be behind IST, leading to failure in deleting
that snapshot.

And further snapshots would be rejected on the volume, as the latest
snapshot would be stuck in deletion.

Signed-off-by: shishir gowda <shishir.gowda@ril.com>