### PR TITLE
Removed a potential deadlock in RBD volume driver

### DIFF
--- a/cinder/volume/drivers/rbd.py
+++ b/cinder/volume/drivers/rbd.py
@@ -313,13 +313,9 @@ class RBDDriver(driver.VolumeDriver):
         LOG.debug("opening connection to ceph cluster (timeout=%s)." %
                   (self.configuration.rados_connect_timeout))
 
-        # NOTE (e0ne): rados is binding to C lbirary librados.
-        # It blocks eventlet loop so we need to run it in a native
-        # python thread.
-        client = tpool.Proxy(
-            self.rados.Rados(
-                rados_id=self.configuration.rbd_user,
-                conffile=self.configuration.rbd_ceph_conf))
+        client = self.rados.Rados(
+            rados_id=self.configuration.rbd_user,
+            conffile=self.configuration.rbd_ceph_conf)
         if pool is not None:
             pool = encodeutils.safe_encode(pool)
         else:

--- a/cinder/volume/drivers/rbd.py
+++ b/cinder/volume/drivers/rbd.py
@@ -313,6 +313,13 @@ class RBDDriver(driver.VolumeDriver):
         LOG.debug("opening connection to ceph cluster (timeout=%s)." %
                   (self.configuration.rados_connect_timeout))
 
+        # NOTE: comment from https://review.openstack.org/#/c/197710 -
+        # According to Python documentation, code can lead to a deadlock if
+        # the spawned thread directly or indirectly attempts to import a
+        # module. python-rados spawns new thread to connect to cluster. So
+        # I removed spawning of new thread to connect to rados. All
+        # long-running operations calls with python-rbd are still
+        # implemented in native Python threads to block eventlet loop.
         client = self.rados.Rados(
             rados_id=self.configuration.rbd_user,
             conffile=self.configuration.rbd_ceph_conf)


### PR DESCRIPTION
Follow up 6fe7b0dc269bb53060f24dc5859707df5fce00a2

Commit 6fe7b0dc269bb53060f24dc5859707df5fce00a2 done for JBS-125 merged
the fix [1] done for bug [2] into our jiocloud repo. But that fix caused a
regression which was fixed by [3]. This commit merged that regression fix
into our jiocloud repo.

[1] - https://review.openstack.org/#/c/175555
[2] - https://bugs.launchpad.net/cinder/+bug/1401335
[3] - https://review.openstack.org/#/c/197710

Closes-Bug: #JBS-125 , #JBS-308, #JBS-309

Merged commit message follows below:

Fix block eventlet threads on rbd calls

Commit Ibaf43858d60e1320c339f2523b5c09c7f7c7f91e caused new problem with
cross thread communication. According to Python documentation, code can
lead to a deadlock if the spawned thread directly or indirectly attempts
to import a module. python-rados spawns new thread to connect to
cluster. So I removed new spawning new thread to connect to rados. All
long-running operations calls whith python-rbd are still implemented in
native Python threads to block eventlet loop.

Change-Id: Ic9971254102914080383b63cd2807e36213dd6eb
Closes-Bug: #1401335

Conflicts:
	cinder/volume/drivers/rbd.py