### PR TITLE
Fail volume deletion if snap is in creating state

### DIFF
--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -341,6 +341,19 @@ class API(base.Base):
                     "snapshots.") % len(snapshots)
             raise exception.InvalidVolume(reason=msg)
 
+	backups = self.db.backup_get_all_by_volume(context, volume_id)
+	if len(backups):
+            for backup in backups:
+                if backup['status'] == 'creating':
+                    LOG.info(_LI('Unable to delete volume: %s, '
+                                 'volume has snapshot %s in creating state.'), volume['id'],
+                                  backup['id'])
+                    msg = _("Volume still has %s snapshot in creating state")
+			    % backup['id'])
+
+		    raise exception.InvalidVolume(reason=msg)
+
+
         # If the volume is encrypted, delete its encryption key from the key
         # manager. This operation makes volume deletion an irreversible process
         # because the volume cannot be decrypted without its key.


### PR DESCRIPTION
Currently the check is in volume layer, we needed to move it to
the api layer

Signed-off-by: shishir gowda <shishir.gowda@ril.com>