### PR TITLE
JBS-389: change actual_size to BigInteger

### DIFF
--- a/cinder/db/sqlalchemy/migrate_repo/versions/047_change_actual_size_to_bigint.py
+++ b/cinder/db/sqlalchemy/migrate_repo/versions/047_change_actual_size_to_bigint.py
@@ -15,7 +15,7 @@
 # Copyright (c) 2016 Shishir Gowda <shishir.gowda@ril.com>
 
 from oslo_log import log as logging
-from sqlalchemy import Column, MetaData, Table, Float, Integer
+from sqlalchemy import Column, MetaData, Table, Float, Integer, BigInteger
 
 from cinder.i18n import _LE
 
@@ -27,13 +27,11 @@ def upgrade(migrate_engine):
     meta.bind = migrate_engine
 
     backups = Table('backups', meta, autoload=True)
-    actual_size = Column('actual_size', Integer())
 
     try:
-        backups.create_column(actual_size)
-        backups.update().values(actual_size=None).execute()
+        backups.c.actual_size.alter(BigInteger())
     except Exception:
-        LOG.error(_LE("Adding actual_size column to backups table failed."))
+        LOG.error(_LE("Changing actual_size to BigInt failed for  backups."))
         raise
 
 
@@ -42,10 +40,9 @@ def downgrade(migrate_engine):
     meta.bind = migrate_engine
 
     backups = Table('backups', meta, autoload=True)
-    actual_size = backups.columns.actual_size
 
     try:
-        backups.drop_column(actual_size)
+        backups.c.actual_size.alter(Integer())
     except Exception:
-        LOG.error(_LE("Dropping actual_size column from backups table failed."))
+        LOG.error(_LE("Changing actual_size from BigInt to Int from backups table failed."))
         raise

--- a/cinder/db/sqlalchemy/models.py
+++ b/cinder/db/sqlalchemy/models.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from oslo_config import cfg
 from oslo_db.sqlalchemy import models
 from oslo_utils import timeutils
-from sqlalchemy import Column, Integer, String, Text, schema, Float
+from sqlalchemy import Column, Integer, String, Text, schema, Float, BigInteger
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship, backref, validates
@@ -534,7 +534,7 @@ class Backup(BASE, CinderBase):
     object_count = Column(Integer)
     time_stamp = Column(String(255))
     version = Column(Float(precision='3,1'))
-    actual_size = Column(Integer(32))
+    actual_size = Column(BigInteger())
 
     @validates('fail_reason')
     def validate_fail_reason(self, key, fail_reason):


### PR DESCRIPTION
Reverted change in 046_add_actual_size_to_backups.py from earlier fix

Update/alter is introduced in 047_change_actual_size_to_bigint.py

Signed-off-by: shishir gowda <shishir@shishirs-MacBook-Pro.local>